### PR TITLE
added dotStyle scaleup

### DIFF
--- a/package.js
+++ b/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'pierreeric:creativepure',
-  version: '0.1.10',
+  version: '0.1.11',
   // Brief, one-line summary of the package.
   summary: 'A set of styles all written with Stylus and inspired from Codrops.',
   // URL to the Git repository containing the source code for this package.
@@ -22,6 +22,7 @@ Package.onUse(function(api) {
       'styles/buttonMorphOverlay.styl',
       'styles/buttonSmall.styl',
       'styles/checkbox.styl',
+      'styles/dotStyle.styl',
       'styles/input.styl',
       'styles/ironprogress.styl',
       'styles/links.styl',

--- a/styles/dotStyle.styl
+++ b/styles/dotStyle.styl
@@ -35,6 +35,9 @@ cpDotStyle(primary, secondary)
         &:focus
           outline none
 
+cpDotStyleScaleup(primary, secondary)
+  cpDotStyle(primary, secondary) //get core styles
+  
   .dotstyle-scaleup
     li
       a

--- a/styles/dotStyle.styl
+++ b/styles/dotStyle.styl
@@ -1,0 +1,50 @@
+cpDotStyle(primary, secondary)
+  .dotstyle
+    ul
+      position relative
+      display inline-block
+      margin 0
+      padding 0
+      list-style none
+      cursor default
+      -webkit-touch-callout none
+      -webkit-user-select none
+      -khtml-user-select none
+      -moz-user-select none
+      -ms-user-select none
+      user-select none
+    li
+      position relative
+      display block
+      float left
+      margin 0 16px
+      width 16px
+      height 16px
+      cursor pointer
+      a
+        top 0
+        left 0
+        width 100%
+        height 100%
+        outline none
+        border-radius 50%
+        background-color secondary
+        text-indent -999em
+        cursor pointer
+        position absolute
+        &:focus
+          outline none
+
+  .dotstyle-scaleup
+    li
+      a
+        -webkit-transition -webkit-transform 0.3s ease, background-color 0.3s ease
+        transition transform 0.3s ease, background-color 0.3s ease
+      &.active
+        a
+          background-color primary
+          -webkit-transform scale(1.5)
+          transform scale(1.5)
+
+  .dotstyle-scaleup li a:hover, .dotstyle-scaleup li a:focus
+    background-color darken(secondary, 10%)


### PR DESCRIPTION
From: http://tympanus.net/Development/DotNavigationStyles/

A nav for scrolling though collections, or any kind of position indicator.

``` styl
@import s(basePath, dotStyle)
cpDotStyleScaleup(brandColor, bgColor) //edit: now cpDotStyleScaleup calls cpDotStyle internally 
```

``` jade
template(name='dotStyle')
  .dotstyle.dotstyle-scaleup
    h2 Dot Nav
    ul
      each example
        li(class="{{active}}"): a
```

``` coffee
Template.dotStyle.onCreated ->
  @active = new ReactiveVar(1)  

Template.dotStyle.helpers
  example: -> [ #replace example with a Collection Cursor
    {id:1}
    {id:2}
    {id:3}
    {id:4}
    {id:5}
  ]
  active: -> 'active' if Template.instance().active.get() is @id

Template.dotStyle.events
  'click a': (e,t) ->
    e.preventDefault()
    Template.instance().active.set @id
```
